### PR TITLE
Fix debounce deprecated warning

### DIFF
--- a/heartbeat.js
+++ b/heartbeat.js
@@ -1,5 +1,5 @@
 Hooks.once('init', function() {
-	const reloadSettings = debounce(() => setheartbeat(null,null,'init'), 100);
+	const reloadSettings = foundry.utils.debounce(() => setheartbeat(null,null,'init'), 100);
 	//console.log("Heartbeat found...");
 	game.settings.register('heartbeat', 'enabledForThisUser', {
         name: 'Enabled for this user',


### PR DESCRIPTION
Remove the warning:
`You are accessing globalThis.debounce which must now be accessed via foundry.utils.debounce
Deprecated since Version 12
Backwards-compatible support will be removed in Version 14
    at Object.logCompatibilityWarning (foundry-esm.js:4609:19)
    at get (foundry-esm.js:66676:25)
    at Object.fn (heartbeat.js:2:25)
    at #call (foundry.js:632:20)
    at Hooks.callAll (foundry.js:589:17)
    at Game.initialize (foundry.js:8980:11)
    at 🎁Game.prototype.initialize#0 (libWrapper-wrapper.js:188:54)
    at window.addEventListener.once (foundry.js:95974:26)`