### PR TITLE
Handle UpdateActor with 0 Controlled token

### DIFF
--- a/heartbeat.js
+++ b/heartbeat.js
@@ -963,3 +963,4 @@ async function loadSystemPresets() {
     }
 }
 
+

--- a/heartbeat.js
+++ b/heartbeat.js
@@ -962,5 +962,3 @@ async function loadSystemPresets() {
         return {}; // No fallback, just return empty object
     }
 }
-
-

--- a/heartbeat.js
+++ b/heartbeat.js
@@ -440,7 +440,10 @@ function getNewHPValue(actor, updates, hpPath) {
 }
 Hooks.on('preUpdateActor', (actor, updates, options, userId) => {
     if (!game.settings.get('heartbeat', 'enabledForThisUser')) return;
-
+	if (canvas.tokens.controlled.length === 0) {// If preUpdateActor is called without a controlled token
+		console.warn("Heartbeat | preUpdateActor called without controlled token.");
+		return;
+	}
     const controlledTokens = canvas.tokens.controlled.map(t => t.actor?.id);
     if (canvas.tokens.controlled.length > 1) {// If more than one actor is selected
         return;
@@ -460,6 +463,10 @@ Hooks.on('preUpdateActor', (actor, updates, options, userId) => {
 });
 Hooks.on('updateActor', (actor, updates, options, userId) => {
     if (!game.settings.get('heartbeat', 'enabledForThisUser')) return;
+	if (canvas.tokens.controlled.length === 0) {// If UpdateActor is called without a controlled token
+		console.warn("Heartbeat | UpdateActor called without controlled token.");
+		return;
+	}
     if (canvas.tokens.controlled.length > 1) {// If more than one actor is selected
         return;
     }
@@ -955,3 +962,4 @@ async function loadSystemPresets() {
         return {}; // No fallback, just return empty object
     }
 }
+


### PR DESCRIPTION
Some modules may cause UpdateToken to be called without controlled tokens for valid reasons (ex: [pf2e-alchemist-remaster-ducttape](https://github.com/thejoester/pf2e-alchemist-remaster-ducttape) ).
While it doesn't break functionality, this will result in a vague error outputing heartbeat and the other module as "detected modules". This error may be a bit misleading on the source of the issue as it is currently.

This PR adds a check for ``token.controlled.length === 0`` before checking if multiple tokens are selected to prevent the error.

Since this error might be an useful warning still for other modules dev and support, I've also added a console.warn to inform that this state has been reached with Heartbeat.